### PR TITLE
fix example: `cipher` doesn't exist yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ require 'aead'
 
 # currently, AES-256-GCM and AES-256-CTR-HMAC-SHA-256 are supported
 mode   = AEAD::Cipher.new('AES-256-GCM')
-key    = cipher.generate_key
-nonce  = cipher.generate_nonce
+key    = mode.generate_key
+nonce  = mode.generate_nonce
 
 cipher    = mode.new(key)
 aead      = cipher.encrypt(nonce, 'authentication data', 'plaintext')


### PR DESCRIPTION
We are calling `cipher.generate_key` and `cipher.generate_nonce`. There is nothing called `cipher` at that point. Those methods are on our `mode` object, which is the class for the specific algorithm we requested with `AEAD::Cipher.new`.
